### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "billardbot",
+  "version": "1.0.0",
+  "description": "",
+  "main": "billardbot.js",
+  "scripts": {
+    "start": "node billardbot.js"
+  },
+ "dependencies": {
+    "discord.js": "11.1.0",
+    "request": "2.81.0"
+  }
+}


### PR DESCRIPTION
Needed to host bot on Heroku. Note that this only allows billardbot to be hosted on Heroku.